### PR TITLE
Fix bucket KeyError on addition and deletion stats, align numbers

### DIFF
--- a/github_pr_stats/github_pr_stats.py
+++ b/github_pr_stats/github_pr_stats.py
@@ -237,21 +237,21 @@ def create_week_range(start, finish):
       week += timedelta(weeks=1)
    return weeks
 
-def bucket_value(value, bucketSize):
+def bucket_value(value, bucketSize, valueLength=0):
    '''Determine which bucket a value resides in.
 
-   For instance, given a bucketSize of 10, the values 10, 16, and 19 all reside
-   in the bucket 10-19, while 20 is in the 20-29 bucket.
+   For instance, given a bucketSize of 10, for the values 10, 16, and 19,
+   10 goes into bucket 1-10, 16 and 19 go into the bucket 11-20.
    '''
    bottom = (value // bucketSize) * bucketSize
-   top = bottom + bucketSize - 1
-   return '%s-%s' % (bottom, top)
+   top = bottom + bucketSize
+   return '{0:{width}}-{1:{width}}'.format(bottom + 1, top, width=valueLength)
 
-def bucketed_range(min, max, bucketSize):
+def bucketed_range(min, max, bucketSize, valueLength=0):
    values = []
    for value in range(min, max + 1, bucketSize):
       top = value + bucketSize - 1
-      values.append('%s-%s' % (value, top))
+      values.append('{0:{width}}-{1:{width}}'.format(value, top, width=valueLength))
    return values
 
 def print_report(subject):
@@ -286,9 +286,15 @@ def print_diff_report(subject, bucketSize):
    statsAnalysis = StatsAnalysis(data, subject)
    print statsAnalysis
 
-   initialize_ordered_dict(stats[subject+'Histogram'], bucketed_range(statsAnalysis.min, statsAnalysis.max, bucketSize), 0)
+   valueLength = len(str(statsAnalysis.max))
+   initialize_ordered_dict(stats[subject+'Histogram'],
+                           bucketed_range(statsAnalysis.min,
+                                          statsAnalysis.max,
+                                          bucketSize,
+                                          valueLength),
+                           0)
    for value in data:
-      bucket = bucket_value(value, bucketSize)
+      bucket = bucket_value(value, bucketSize, valueLength)
       stats[subject+'Histogram'][bucket] += 1
    print_histogram(stats[subject+'Histogram'].items())
 

--- a/github_pr_stats/github_pr_stats.py
+++ b/github_pr_stats/github_pr_stats.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # May you recognize your weaknesses and share your strengths.
 # May you share freely, never taking more than you give.
 # May you find love and love everyone you find.
@@ -237,22 +238,45 @@ def create_week_range(start, finish):
       week += timedelta(weeks=1)
    return weeks
 
-def bucket_value(value, bucketSize, valueLength=0):
+def bucket_value(value, bucketSize):
    '''Determine which bucket a value resides in.
 
-   For instance, given a bucketSize of 10, for the values 10, 16, and 19,
-   10 goes into bucket 1-10, 16 and 19 go into the bucket 11-20.
+   >>> bucket_value(1, 10)
+   0
+   >>> bucket_value(9, 10)
+   0
+   >>> bucket_value(10, 10)
+   1
+   >>> bucket_value(0, 10)
+   Traceback (most recent call last):
+      ...
+   ValueError: value must be positive
    '''
-   bottom = (value // bucketSize) * bucketSize
-   top = bottom + bucketSize
-   return '{0:{width}}-{1:{width}}'.format(bottom + 1, top, width=valueLength)
+   if value <= 0:
+      raise ValueError('value must be positive')
+   return value // bucketSize
 
-def bucketed_range(min, max, bucketSize, valueLength=0):
-   values = []
-   for value in range(min, max + 1, bucketSize):
-      top = value + bucketSize - 1
-      values.append('{0:{width}}-{1:{width}}'.format(value, top, width=valueLength))
-   return values
+def bucketed_range(min, max, bucketSize):
+   '''Return a list of bucket indexes
+
+   >>> bucketed_range(3, 15, 10)
+   [0, 1]
+   >>> bucketed_range(13, 50, 10)
+   [1, 2, 3, 4]
+   >>> bucketed_range(-3, 50, 10)
+   Traceback (most recent call last):
+      ...
+   ValueError: min and max must be positive
+   >>> bucketed_range(30, 5, 10)
+   Traceback (most recent call last):
+      ...
+   ValueError: min must be smaller or equal to max
+   '''
+   if min <= 0 or max <= 0:
+      raise ValueError('min and max must be positive')
+   if min > max:
+      raise ValueError('min must be smaller or equal to max')
+   return [value // bucketSize for value in range(min, max + 1, bucketSize)]
 
 def print_report(subject):
    '''Do various calculations on the subject, then print the results.
@@ -282,21 +306,43 @@ def print_date_report(subject, name):
    print_histogram(allData.items(), name)
 
 def print_diff_report(subject, bucketSize):
+   '''Print report for additions and deletions
+
+   >>> from github_pr_stats import stats
+   >>> stats['foo'] = [1, 2, 3, 14]
+   >>> stats['fooHistogram'] = OrderedDict()
+   >>> stats['count'] = sum(stats['foo'])
+   >>> print_diff_report('foo', 10)
+   foo: 5.0 (mean) 2.5 (median) 5.24404424085 (std. dev.) 1 (min) 14 (max)
+   <BLANKLINE>
+   ###############################################################################
+   ███████████████████████████████████████████████████████████  3  ( 15.00%)  1-10
+   ███████████████████                                          1  (  5.00%) 11-20
+   '''
    data = array(stats[subject])
    statsAnalysis = StatsAnalysis(data, subject)
    print statsAnalysis
 
-   valueLength = len(str(statsAnalysis.max))
+   # No data?
+   if (data == array([0])).all():
+      return
+
    initialize_ordered_dict(stats[subject+'Histogram'],
                            bucketed_range(statsAnalysis.min,
                                           statsAnalysis.max,
-                                          bucketSize,
-                                          valueLength),
+                                          bucketSize),
                            0)
+   valueLength = len(str((statsAnalysis.max // bucketSize) * bucketSize + bucketSize))
    for value in data:
-      bucket = bucket_value(value, bucketSize, valueLength)
+      bucket = bucket_value(value, bucketSize)
       stats[subject+'Histogram'][bucket] += 1
-   print_histogram(stats[subject+'Histogram'].items())
+   aligned_stats = OrderedDict()
+   for bucket, value in stats[subject+'Histogram'].items():
+      bucket = '{0:{width}}-{1:{width}}'.format(bucket * bucketSize + 1,
+                                                (bucket + 1) * bucketSize,
+                                                width=valueLength)
+      aligned_stats[bucket] = value
+   print_histogram(aligned_stats.items())
 
 class StatsAnalysis(object):
    def __init__(self, data, subject=''):


### PR DESCRIPTION
The keys were generated differently by `bucket_value()` and `bucketed_range()`, 10-19 and 11-20, respectively. They didn't match, therefore a KeyError.

1-10 should be right bucket range, since we won't see 0 additions or deletions. I also added valueLength in order to align the key better for the presentation.