### PR TITLE
Upgrade distribute to 0.7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ env
 MANIFEST
 dist
 *.egg-info
-
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ascii-graph==0.2.1
-distribute==0.6.34
+distribute==0.7.3
 docopt==0.6.1
 envoy==0.0.2
 github3.py==0.8.1


### PR DESCRIPTION
With distribute 0.6.34, I encounter a 'sys_platform' not defined error under Python 2.7.11.
