### PR TITLE
Fix "Until" Parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ env
 MANIFEST
 dist
 *.egg-info
-
+build/
+*.pyc

--- a/github_pr_stats/github_pr_stats.py
+++ b/github_pr_stats/github_pr_stats.py
@@ -86,7 +86,7 @@ def analyze(token, config, user, repo=None, since=None, until=None, \
 
       for issue in repo.iter_issues(state='closed', direction='asc', since=since):
          if until and issue.created_at >= until:
-            break
+            continue
 
          # The 'since' parameter always applies to updates, even if we specify a
          # 'sort' of, say, creation date, so we can't rely on it to filter out

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[easy_install]
+


### PR DESCRIPTION
Currently, when trying to use the "until" parameter, the following error is received:

```
ValueError: zero-size array to reduction operation minimum which has no identity
```

It appears that the call to `repo.iter_issues(...)` is returning the pull requests in descending order, apparently ignoring the `direction` parameter. Therefore, as soon as it hits the first pull request, it sees that the `created_at` date is after the `until` value and immediately exits.  Changing this to be a `continue` instead of a `break` fixes the issue, though is unfortunately inefficient.
