### PR TITLE
Replace distribute package with setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ascii-graph==0.2.1
-distribute==0.6.34
+setuptools==40.2.0
 docopt==0.6.1
 envoy==0.0.2
 github3.py==0.8.1


### PR DESCRIPTION
https://pypi.org/project/distribute/#description

Distribute is a legacy package. It is a simple compatibility layer that installs Setuptools 0.7+.